### PR TITLE
[BCORE-3585] chore: add Atlassian Compass configuration (compass.yaml)

### DIFF
--- a/compass.yaml
+++ b/compass.yaml
@@ -1,0 +1,25 @@
+name: symfony-messenger-enqueue-transport
+slug: symfony-messenger-enqueue-transport
+description: 'Uses Enqueue with Symfony''s Messenger component.'
+configVersion: 1
+typeId: LIBRARY
+ownerId: 'ari:cloud:identity::team/213646a7-05d6-4792-b784-ded22e4db466'
+
+fields:
+  isMonorepoProject: false
+  lifecycle: Active
+  tier: 3
+
+links:
+  - name: 'betterme-dev/symfony-messenger-enqueue-transport'
+    type: REPOSITORY
+    url: 'https://github.com/betterme-dev/symfony-messenger-enqueue-transport'
+
+labels:
+  - 'cop:mobile-backend'
+  - 'symfony'
+
+customFields:
+  - name: Department
+    type: single_select
+    displayValue: 'Mobile'

--- a/compass.yaml
+++ b/compass.yaml
@@ -1,6 +1,6 @@
 name: symfony-messenger-enqueue-transport
 slug: symfony-messenger-enqueue-transport
-description: 'Uses Enqueue with Symfony''s Messenger component.'
+description: "Uses Enqueue with Symfony's Messenger component."
 configVersion: 1
 typeId: LIBRARY
 ownerId: 'ari:cloud:identity::team/213646a7-05d6-4792-b784-ded22e4db466'
@@ -11,13 +11,15 @@ fields:
   tier: 3
 
 links:
-  - name: 'betterme-dev/symfony-messenger-enqueue-transport'
+  - name: betterme-dev/symfony-messenger-enqueue-transport
     type: REPOSITORY
     url: 'https://github.com/betterme-dev/symfony-messenger-enqueue-transport'
 
 labels:
+  - 'app-framework:symfony'
   - 'cop:mobile-backend'
-  - 'symfony'
+  - 'language:php'
+  - source:github
 
 customFields:
   - name: Department


### PR DESCRIPTION
## Atlassian Compass Registration

This PR adds `compass.yaml` to register this repository as a component in Atlassian Compass.

### What is compass.yaml?
Config-as-code file that defines component metadata (ownership, type, links, relationships). Automatically synced with Compass.

### Next Steps
- [ ] Review generated metadata
- [ ] Verify tier and lifecycle values
- [ ] Add missing links (dashboards, on-call, Slack channels)
- [ ] Mark as ready for review
- [ ] Merge to sync with Compass

Jira: [BCORE-3585](https://newsiteam.atlassian.net/browse/BCORE-3585)

[BCORE-3585]: https://newsiteam.atlassian.net/browse/BCORE-3585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ